### PR TITLE
Fixes bug with debouncing of window resize event binding

### DIFF
--- a/dist/base.js
+++ b/dist/base.js
@@ -1,5 +1,3 @@
-/* base.js v0.0.29 */ 
-
 (function (Ractive) {
 
   Ractive.adaptors.backboneAssociatedModel = function ( model, path ) {
@@ -993,13 +991,13 @@
         this.template = _JST["src/templates/app.html"];
       }
       $win = $(window);
-      $win.on("resize.appResize-" + this.cid, _.debounce(50, function() {
+      $win.on("resize.appResize-" + this.cid, _.debounce(function() {
         return _this.set({
           windowWidth: $win.width(),
           windowHeight: $win.height(),
           documentWidth: document.width,
           documentHeight: document.height
-        });
+        }, 50);
       }));
       App.__super__.constructor.apply(this, arguments);
     }

--- a/src/coffee/base.coffee
+++ b/src/coffee/base.coffee
@@ -559,12 +559,13 @@ class Base.App extends Base.View
     @template ?= _JST["src/templates/app.html"]
 
     $win = $ window
-    $win.on "resize.appResize-#{@cid}", _.debounce 50, =>
+    $win.on "resize.appResize-#{@cid}", _.debounce =>
       @set
         windowWidth: $win.width(),
         windowHeight: $win.height(),
         documentWidth: document.width,
         documentHeight: document.height
+      , 50
 
     super
 


### PR DESCRIPTION
This fixes the console error: Uncaught TypeError: Object 50 has no method 'apply' . The _.debounce wait argument just needed to be passed after the callback.

Also, what type of build should I do before submitting a pull request?
